### PR TITLE
feat: remove the unnecessary permissions from the Node.js prepare job

### DIFF
--- a/.github/workflows/nodejs-prepare-release.yml
+++ b/.github/workflows/nodejs-prepare-release.yml
@@ -30,9 +30,6 @@ on:
 jobs:
   prepare:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - name: Validate inputs
         env:


### PR DESCRIPTION
The default GITHUB_TOKEN isn't actually used as a PAT is needed to trigger the publish workflow.