### PR TITLE
feat: publish pre-packaged NPM package

### DIFF
--- a/.github/workflows/nodejs-publish-release.yml
+++ b/.github/workflows/nodejs-publish-release.yml
@@ -111,7 +111,10 @@ jobs:
           git push origin "v$RELEASE_VERSION"
 
       - name: Pack npm artifact
-        run: npm pack
+        id: pack
+        run: |
+          TARBALL=$(npm pack)
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
 
       - name: Extract release notes from changelog
         env:
@@ -142,7 +145,7 @@ jobs:
             --title "v$RELEASE_VERSION" \
             --notes-file release-notes.md \
             $PRERELEASE_FLAG \
-            ./*.tgz
+            "${{ steps.pack.outputs.tarball }}"
 
       - name: Publish to npm
         env:
@@ -155,7 +158,7 @@ jobs:
             exit 1
           fi
           if [[ "$RELEASE_VERSION" == *"-"* ]]; then
-            npm publish --access public --provenance --tag next
+            npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance --tag next
           else
-            npm publish --access public --provenance
+            npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance
           fi

--- a/.github/workflows/nodejs-publish-release.yml
+++ b/.github/workflows/nodejs-publish-release.yml
@@ -110,6 +110,9 @@ jobs:
           git tag "v$RELEASE_VERSION"
           git push origin "v$RELEASE_VERSION"
 
+      - name: Pack npm artifact
+        run: npm pack
+
       - name: Extract release notes from changelog
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
@@ -125,9 +128,6 @@ jobs:
             echo "::error::Could not extract release notes for v$RELEASE_VERSION from CHANGELOG.md"
             exit 1
           fi
-
-      - name: Pack npm artifact
-        run: npm pack
 
       - name: Create GitHub release
         env:


### PR DESCRIPTION
Previously, all the checks passed then the release notes were extracted from the changelog and saved to a temporary file, then the NPM package was packaged which included the temporary release notes file. Then the publish command was performing the checks again as the pre-publish steps which now included the release notes which had blank lines at the beginning and end of the file.

This had a few problems:

1. The extra blank lines in the release notes should be removed.
2. The temporary release-notes file should not be packaged as it is not tracked in git.
3. The published package is potentially different to the package uploaded to the GitHub release.

This PR addresses points `2.` and `3.` but the blank newlines (`1.`) are ignored because GitHub doesn't render them in the release notes section anyway and I don't want to over-complicate the `awk` command.