### PR TITLE
fix: Node.js publish release workflow

### DIFF
--- a/.github/workflows/nodejs-publish-release.yml
+++ b/.github/workflows/nodejs-publish-release.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: "https://registry.npmjs.org"
-          cache: ${{ inputs.package_manager }}
+          package-manager-cache: false # never use caching in release builds
 
       - name: Install dependencies
         env:

--- a/.github/workflows/nodejs-publish-release.yml
+++ b/.github/workflows/nodejs-publish-release.yml
@@ -18,6 +18,10 @@ on:
         description: "npm script name to run for building the project"
         default: "build"
         required: false
+    secrets:
+      NPM_TOKEN:
+        description: "npm authentication token for publishing, leave blank if using Trusted Publishers"
+        required: false
 
 jobs:
   check:
@@ -146,6 +150,7 @@ jobs:
       - name: Publish to npm
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           PACKAGE_NAME=$(node -p "require('./package.json').name")
           if npm view "$PACKAGE_NAME@$RELEASE_VERSION" > /dev/null 2>&1; then

--- a/.github/workflows/nodejs-publish-release.yml
+++ b/.github/workflows/nodejs-publish-release.yml
@@ -6,7 +6,7 @@ on:
       node_version:
         type: string
         description: "Node.js version to use"
-        default: "22"
+        default: "24"
         required: false
       package_manager:
         type: string


### PR DESCRIPTION
This time it actually does work, I tested it here: https://github.com/holochain/hc-spin/actions/runs/27209734639/job/80335171989

It appears that there was a bug with Trusted Publishers in Node.js v22 (even though the docs claim it should work) after updating to v24 it works.

I also took this oppotunity to disable the caching option (which should be done for release builds) as well as adding `NPM_TOKEN` back as an optional secret so that this workflow can hopefully be used by projects that are not using Trusted Publishers.