### PR TITLE
feat: add support for napi-rs

### DIFF
--- a/.github/workflows/nodejs-prepare-release.yml
+++ b/.github/workflows/nodejs-prepare-release.yml
@@ -15,7 +15,7 @@ on:
       node_version:
         type: string
         description: "Node.js version to use"
-        default: "22"
+        default: "24"
         required: false
       package_manager:
         type: string

--- a/.github/workflows/nodejs-prepare-release.yml
+++ b/.github/workflows/nodejs-prepare-release.yml
@@ -22,6 +22,11 @@ on:
         description: "Package manager used by the project: npm, yarn, or pnpm"
         default: "npm"
         required: false
+      install_deps:
+        type: boolean
+        description: "Whether to install dependencies before preparing the release"
+        default: false
+        required: false
     secrets:
       GH_TOKEN:
         description: "GitHub token with permission to create pull requests"
@@ -31,27 +36,16 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     steps:
-      - name: Validate inputs
-        env:
-          PACKAGE_MANAGER: ${{ inputs.package_manager }}
-        run: |
-          case "$PACKAGE_MANAGER" in
-            npm|yarn|pnpm) ;;
-            *) echo "::error::Unsupported package_manager '$PACKAGE_MANAGER'. Must be one of: npm, yarn, pnpm." && exit 1 ;;
-          esac
-
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup pnpm
-        if: inputs.package_manager == 'pnpm'
-        uses: pnpm/action-setup@v6
-
-      - uses: actions/setup-node@v6
+      - uses: ./nodejs-setup
         with:
-          node-version: ${{ inputs.node_version }}
+          node_version: ${{ inputs.node_version }}
+          package_manager: ${{ inputs.package_manager }}
+          install_deps: ${{ inputs.install_deps }}
 
       - name: Install git-cliff
         uses: taiki-e/install-action@v2

--- a/.github/workflows/nodejs-publish-release.yml
+++ b/.github/workflows/nodejs-publish-release.yml
@@ -46,119 +46,22 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - name: Validate inputs
-        env:
-          PACKAGE_MANAGER: ${{ inputs.package_manager }}
-        run: |
-          case "$PACKAGE_MANAGER" in
-            npm|yarn|pnpm) ;;
-            *) echo "::error::Unsupported package_manager '$PACKAGE_MANAGER'. Must be one of: npm, yarn, pnpm." && exit 1 ;;
-          esac
-
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup pnpm
-        if: inputs.package_manager == 'pnpm'
-        uses: pnpm/action-setup@v6
-
-      - uses: actions/setup-node@v6
+      - uses: ./nodejs-setup
         with:
-          node-version: ${{ inputs.node_version }}
-          registry-url: "https://registry.npmjs.org"
-          package-manager-cache: false # never use caching in release builds
+          node_version: ${{ inputs.node_version }}
+          package_manager: ${{ inputs.package_manager }}
+          cache: false # never use caching in release builds
 
-      - name: Install dependencies
-        env:
-          PACKAGE_MANAGER: ${{ inputs.package_manager }}
-        run: |
-          case "$PACKAGE_MANAGER" in
-            yarn) yarn install --frozen-lockfile ;;
-            pnpm) pnpm install --frozen-lockfile ;;
-            npm) npm ci ;;
-          esac
+      - uses: ./nodejs-build
+        with:
+          package_manager: ${{ inputs.package_manager }}
+          build_script: ${{ inputs.build_script }}
 
-      - name: Build
-        env:
-          PACKAGE_MANAGER: ${{ inputs.package_manager }}
-          BUILD_SCRIPT: ${{ inputs.build_script }}
-        run: |
-          case "$PACKAGE_MANAGER" in
-            yarn) yarn "$BUILD_SCRIPT" ;;
-            pnpm) pnpm run "$BUILD_SCRIPT" ;;
-            npm) npm run "$BUILD_SCRIPT" ;;
-          esac
-
-      - name: Get version
-        id: version
-        run: echo "value=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
-
-      - name: Create and push tag
-        env:
-          RELEASE_VERSION: ${{ steps.version.outputs.value }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-          if git ls-remote --tags origin "v$RELEASE_VERSION" | grep -q .; then
-            echo "::error::Tag v$RELEASE_VERSION already exists. Was this release already published?"
-            exit 1
-          fi
-          git tag "v$RELEASE_VERSION"
-          git push origin "v$RELEASE_VERSION"
-
-      - name: Pack npm artifact
-        id: pack
-        run: |
-          TARBALL=$(npm pack)
-          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
-
-      - name: Extract release notes from changelog
-        env:
-          RELEASE_VERSION: ${{ steps.version.outputs.value }}
-        run: |
-          awk -v version="$RELEASE_VERSION" '
-            /^## / {
-              if (found) exit
-              if (index($0, version) > 0) { found = 1; next }
-            }
-            found { print }
-          ' CHANGELOG.md > release-notes.md
-          if [ ! -s release-notes.md ]; then
-            echo "::error::Could not extract release notes for v$RELEASE_VERSION from CHANGELOG.md"
-            exit 1
-          fi
-
-      - name: Create GitHub release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_VERSION: ${{ steps.version.outputs.value }}
-        run: |
-          PRERELEASE_FLAG=""
-          if [[ "$RELEASE_VERSION" == *"-"* ]]; then
-            PRERELEASE_FLAG="--prerelease"
-          fi
-          gh release create "v$RELEASE_VERSION" \
-            --title "v$RELEASE_VERSION" \
-            --notes-file release-notes.md \
-            $PRERELEASE_FLAG \
-            "${{ steps.pack.outputs.tarball }}"
-
-      - name: Publish to npm
-        env:
-          RELEASE_VERSION: ${{ steps.version.outputs.value }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          PACKAGE_NAME=$(node -p "require('./package.json').name")
-          if npm view "$PACKAGE_NAME@$RELEASE_VERSION" > /dev/null 2>&1; then
-            echo "::error::$PACKAGE_NAME@$RELEASE_VERSION is already published to npm. Was this release already published?"
-            exit 1
-          fi
-          if [[ "$RELEASE_VERSION" == *"-"* ]]; then
-            npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance --tag next
-          else
-            npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance
-          fi
+      - uses: ./nodejs-publish
+        with:
+          npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/nodejs-publish-release.yml
+++ b/.github/workflows/nodejs-publish-release.yml
@@ -56,6 +56,7 @@ jobs:
           node_version: ${{ inputs.node_version }}
           package_manager: ${{ inputs.package_manager }}
           cache: false # never use caching in release builds
+          install_deps: true
 
       - uses: ./nodejs-build
         with:

--- a/nodejs-build/action.yml
+++ b/nodejs-build/action.yml
@@ -1,0 +1,28 @@
+name: Build Node.js project
+description: Run the build script for a Node.js project
+
+inputs:
+  package_manager:
+    description: "Package manager used by the project: npm, yarn, or pnpm"
+    default: "npm"
+    required: false
+  build_script:
+    description: "npm script name to run for building the project"
+    default: "build"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Build
+      shell: bash
+      env:
+        PACKAGE_MANAGER: ${{ inputs.package_manager }}
+        BUILD_SCRIPT: ${{ inputs.build_script }}
+      run: |
+        case "$PACKAGE_MANAGER" in
+          yarn) yarn "$BUILD_SCRIPT" ;;
+          pnpm) pnpm run "$BUILD_SCRIPT" ;;
+          npm) npm run "$BUILD_SCRIPT" ;;
+          *) echo "::error::Unsupported package_manager '$PACKAGE_MANAGER'. Must be one of: npm, yarn, pnpm." && exit 1 ;;
+        esac

--- a/nodejs-publish/action.yml
+++ b/nodejs-publish/action.yml
@@ -72,7 +72,8 @@ runs:
           exit 1
         fi
 
-    - name: Create GitHub release
+    # If the release exists now but not in the check step then it was most likely created during the publish, for example with napi-rs.
+    - name: Create or update GitHub release
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -82,8 +83,18 @@ runs:
         if [[ "$RELEASE_VERSION" == *"-"* ]]; then
           PRERELEASE_FLAG="--prerelease"
         fi
-        gh release create "v$RELEASE_VERSION" \
-          --title "v$RELEASE_VERSION" \
-          --notes-file /tmp/release-notes.md \
-          $PRERELEASE_FLAG \
-          "${{ steps.pack.outputs.tarball }}"
+        if gh release view "v$RELEASE_VERSION" > /dev/null 2>&1; then
+          TAG_COMMIT=$(gh api "repos/${{ github.repository }}/commits/v$RELEASE_VERSION" --jq '.sha')
+          if [ "$TAG_COMMIT" != "$GITHUB_SHA" ]; then
+            echo "::error::Release v$RELEASE_VERSION exists but its tag points to a different commit. Was this release already published?"
+            exit 1
+          fi
+          gh release edit "v$RELEASE_VERSION" --title "v$RELEASE_VERSION" --notes-file /tmp/release-notes.md $PRERELEASE_FLAG
+          gh release upload "v$RELEASE_VERSION" "${{ steps.pack.outputs.tarball }}"
+        else
+          gh release create "v$RELEASE_VERSION" \
+            --title "v$RELEASE_VERSION" \
+            --notes-file /tmp/release-notes.md \
+            $PRERELEASE_FLAG \
+            "${{ steps.pack.outputs.tarball }}"
+        fi

--- a/nodejs-publish/action.yml
+++ b/nodejs-publish/action.yml
@@ -40,6 +40,7 @@ runs:
       env:
         RELEASE_VERSION: ${{ steps.version.outputs.value }}
         NODE_AUTH_TOKEN: ${{ inputs.npm_token }}
+        GITHUB_TOKEN: ${{ github.token }} # Required for napi-rs support
       run: |
         if [[ "$RELEASE_VERSION" == *"-"* ]]; then
           npm publish --access public --provenance --tag next

--- a/nodejs-publish/action.yml
+++ b/nodejs-publish/action.yml
@@ -14,17 +14,33 @@ runs:
       shell: bash
       run: echo "value=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
+    - name: Check version does not already exist
+      shell: bash
+      env:
+        RELEASE_VERSION: ${{ steps.version.outputs.value }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        PACKAGE_NAME=$(node -p "require('./package.json').name")
+        if npm view "$PACKAGE_NAME@$RELEASE_VERSION" > /dev/null 2>&1; then
+          echo "::error::$PACKAGE_NAME@$RELEASE_VERSION is already published to npm."
+          exit 1
+        fi
+        if gh release view "v$RELEASE_VERSION" > /dev/null 2>&1; then
+          echo "::error::Release v$RELEASE_VERSION already exists on GitHub but was not published to NPM. Publish it manually."
+          exit 1
+        fi
+        TAG_COMMIT=$(git rev-list -n 1 "v$RELEASE_VERSION" 2>/dev/null || echo "")
+        if [ -n "$TAG_COMMIT" ] && [ "$TAG_COMMIT" != "$GITHUB_SHA" ]; then
+          echo "::error::Tag v$RELEASE_VERSION already exists, without a release, on a different commit. Delete the tag if you want a new release."
+          exit 1
+        fi
+
     - name: Publish to npm
       shell: bash
       env:
         RELEASE_VERSION: ${{ steps.version.outputs.value }}
         NODE_AUTH_TOKEN: ${{ inputs.npm_token }}
       run: |
-        PACKAGE_NAME=$(node -p "require('./package.json').name")
-        if npm view "$PACKAGE_NAME@$RELEASE_VERSION" > /dev/null 2>&1; then
-          echo "::error::$PACKAGE_NAME@$RELEASE_VERSION is already published to npm. Was this release already published?"
-          exit 1
-        fi
         if [[ "$RELEASE_VERSION" == *"-"* ]]; then
           npm publish --access public --provenance --tag next
         else
@@ -62,15 +78,6 @@ runs:
         GH_TOKEN: ${{ github.token }}
         RELEASE_VERSION: ${{ steps.version.outputs.value }}
       run: |
-        if gh release view "v$RELEASE_VERSION" > /dev/null 2>&1; then
-          echo "::error::Release v$RELEASE_VERSION already exists. Was this release already published?"
-          exit 1
-        fi
-        TAG_COMMIT=$(git rev-list -n 1 "v$RELEASE_VERSION" 2>/dev/null || echo "")
-        if [ -n "$TAG_COMMIT" ] && [ "$TAG_COMMIT" != "$GITHUB_SHA" ]; then
-          echo "::error::Tag v$RELEASE_VERSION already exists, without a release, on a different commit. Was this release already published?"
-          exit 1
-        fi
         PRERELEASE_FLAG=""
         if [[ "$RELEASE_VERSION" == *"-"* ]]; then
           PRERELEASE_FLAG="--prerelease"

--- a/nodejs-publish/action.yml
+++ b/nodejs-publish/action.yml
@@ -14,6 +14,31 @@ runs:
       shell: bash
       run: echo "value=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
+    - name: Publish to npm
+      shell: bash
+      env:
+        RELEASE_VERSION: ${{ steps.version.outputs.value }}
+        NODE_AUTH_TOKEN: ${{ inputs.npm_token }}
+      run: |
+        PACKAGE_NAME=$(node -p "require('./package.json').name")
+        if npm view "$PACKAGE_NAME@$RELEASE_VERSION" > /dev/null 2>&1; then
+          echo "::error::$PACKAGE_NAME@$RELEASE_VERSION is already published to npm. Was this release already published?"
+          exit 1
+        fi
+        if [[ "$RELEASE_VERSION" == *"-"* ]]; then
+          npm publish --access public --provenance --tag next
+        else
+          npm publish --access public --provenance
+        fi
+
+    # Must publish before packing so that the prepublishOnly script is run on the package.
+    - name: Pack npm artifact
+      id: pack
+      shell: bash
+      run: |
+        TARBALL=$(npm pack)
+        echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+
     - name: Create and push tag
       shell: bash
       env:
@@ -29,13 +54,6 @@ runs:
         fi
         git tag "v$RELEASE_VERSION"
         git push origin "v$RELEASE_VERSION"
-
-    - name: Pack npm artifact
-      id: pack
-      shell: bash
-      run: |
-        TARBALL=$(npm pack)
-        echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
 
     - name: Extract release notes from changelog
       shell: bash
@@ -69,20 +87,3 @@ runs:
           --notes-file release-notes.md \
           $PRERELEASE_FLAG \
           "${{ steps.pack.outputs.tarball }}"
-
-    - name: Publish to npm
-      shell: bash
-      env:
-        RELEASE_VERSION: ${{ steps.version.outputs.value }}
-        NODE_AUTH_TOKEN: ${{ inputs.npm_token }}
-      run: |
-        PACKAGE_NAME=$(node -p "require('./package.json').name")
-        if npm view "$PACKAGE_NAME@$RELEASE_VERSION" > /dev/null 2>&1; then
-          echo "::error::$PACKAGE_NAME@$RELEASE_VERSION is already published to npm. Was this release already published?"
-          exit 1
-        fi
-        if [[ "$RELEASE_VERSION" == *"-"* ]]; then
-          npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance --tag next
-        else
-          npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance
-        fi

--- a/nodejs-publish/action.yml
+++ b/nodejs-publish/action.yml
@@ -1,0 +1,88 @@
+name: Publish Node.js release
+description: Create a git tag, GitHub release, and publish to npm
+
+inputs:
+  npm_token:
+    description: "npm authentication token for publishing, leave blank if using Trusted Publishers"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Get version
+      id: version
+      shell: bash
+      run: echo "value=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+    - name: Create and push tag
+      shell: bash
+      env:
+        RELEASE_VERSION: ${{ steps.version.outputs.value }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+        if git ls-remote --tags origin "v$RELEASE_VERSION" | grep -q .; then
+          echo "::error::Tag v$RELEASE_VERSION already exists. Was this release already published?"
+          exit 1
+        fi
+        git tag "v$RELEASE_VERSION"
+        git push origin "v$RELEASE_VERSION"
+
+    - name: Pack npm artifact
+      id: pack
+      shell: bash
+      run: |
+        TARBALL=$(npm pack)
+        echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+
+    - name: Extract release notes from changelog
+      shell: bash
+      env:
+        RELEASE_VERSION: ${{ steps.version.outputs.value }}
+      run: |
+        awk -v version="$RELEASE_VERSION" '
+          /^## / {
+            if (found) exit
+            if (index($0, version) > 0) { found = 1; next }
+          }
+          found { print }
+        ' CHANGELOG.md > release-notes.md
+        if [ ! -s release-notes.md ]; then
+          echo "::error::Could not extract release notes for v$RELEASE_VERSION from CHANGELOG.md"
+          exit 1
+        fi
+
+    - name: Create GitHub release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_VERSION: ${{ steps.version.outputs.value }}
+      run: |
+        PRERELEASE_FLAG=""
+        if [[ "$RELEASE_VERSION" == *"-"* ]]; then
+          PRERELEASE_FLAG="--prerelease"
+        fi
+        gh release create "v$RELEASE_VERSION" \
+          --title "v$RELEASE_VERSION" \
+          --notes-file release-notes.md \
+          $PRERELEASE_FLAG \
+          "${{ steps.pack.outputs.tarball }}"
+
+    - name: Publish to npm
+      shell: bash
+      env:
+        RELEASE_VERSION: ${{ steps.version.outputs.value }}
+        NODE_AUTH_TOKEN: ${{ inputs.npm_token }}
+      run: |
+        PACKAGE_NAME=$(node -p "require('./package.json').name")
+        if npm view "$PACKAGE_NAME@$RELEASE_VERSION" > /dev/null 2>&1; then
+          echo "::error::$PACKAGE_NAME@$RELEASE_VERSION is already published to npm. Was this release already published?"
+          exit 1
+        fi
+        if [[ "$RELEASE_VERSION" == *"-"* ]]; then
+          npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance --tag next
+        else
+          npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance
+        fi

--- a/nodejs-publish/action.yml
+++ b/nodejs-publish/action.yml
@@ -1,5 +1,5 @@
 name: Publish Node.js release
-description: Create a git tag, GitHub release, and publish to npm
+description: Create a GitHub release and publish to npm
 
 inputs:
   npm_token:
@@ -39,22 +39,6 @@ runs:
         TARBALL=$(npm pack)
         echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
 
-    - name: Create and push tag
-      shell: bash
-      env:
-        RELEASE_VERSION: ${{ steps.version.outputs.value }}
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-        if git ls-remote --tags origin "v$RELEASE_VERSION" | grep -q .; then
-          echo "::error::Tag v$RELEASE_VERSION already exists. Was this release already published?"
-          exit 1
-        fi
-        git tag "v$RELEASE_VERSION"
-        git push origin "v$RELEASE_VERSION"
-
     - name: Extract release notes from changelog
       shell: bash
       env:
@@ -78,6 +62,10 @@ runs:
         GH_TOKEN: ${{ github.token }}
         RELEASE_VERSION: ${{ steps.version.outputs.value }}
       run: |
+        if gh release view "v$RELEASE_VERSION" > /dev/null 2>&1; then
+          echo "::error::Release v$RELEASE_VERSION already exists. Was this release already published?"
+          exit 1
+        fi
         PRERELEASE_FLAG=""
         if [[ "$RELEASE_VERSION" == *"-"* ]]; then
           PRERELEASE_FLAG="--prerelease"

--- a/nodejs-publish/action.yml
+++ b/nodejs-publish/action.yml
@@ -66,8 +66,8 @@ runs:
             if (index($0, version) > 0) { found = 1; next }
           }
           found { print }
-        ' CHANGELOG.md > release-notes.md
-        if [ ! -s release-notes.md ]; then
+        ' CHANGELOG.md > /tmp/release-notes.md
+        if [ ! -s /tmp/release-notes.md ]; then
           echo "::error::Could not extract release notes for v$RELEASE_VERSION from CHANGELOG.md"
           exit 1
         fi
@@ -84,6 +84,6 @@ runs:
         fi
         gh release create "v$RELEASE_VERSION" \
           --title "v$RELEASE_VERSION" \
-          --notes-file release-notes.md \
+          --notes-file /tmp/release-notes.md \
           $PRERELEASE_FLAG \
           "${{ steps.pack.outputs.tarball }}"

--- a/nodejs-publish/action.yml
+++ b/nodejs-publish/action.yml
@@ -66,6 +66,11 @@ runs:
           echo "::error::Release v$RELEASE_VERSION already exists. Was this release already published?"
           exit 1
         fi
+        TAG_COMMIT=$(git rev-list -n 1 "v$RELEASE_VERSION" 2>/dev/null || echo "")
+        if [ -n "$TAG_COMMIT" ] && [ "$TAG_COMMIT" != "$GITHUB_SHA" ]; then
+          echo "::error::Tag v$RELEASE_VERSION already exists, without a release, on a different commit. Was this release already published?"
+          exit 1
+        fi
         PRERELEASE_FLAG=""
         if [[ "$RELEASE_VERSION" == *"-"* ]]; then
           PRERELEASE_FLAG="--prerelease"

--- a/nodejs-publish/action.yml
+++ b/nodejs-publish/action.yml
@@ -1,5 +1,5 @@
 name: Publish Node.js release
-description: Create a GitHub release and publish to npm
+description: Create a git tag, GitHub release, and publish to npm
 
 inputs:
   npm_token:
@@ -33,6 +33,22 @@ runs:
         if [ -n "$TAG_COMMIT" ] && [ "$TAG_COMMIT" != "$GITHUB_SHA" ]; then
           echo "::error::Tag v$RELEASE_VERSION already exists, without a release, on a different commit. Delete the tag if you want a new release."
           exit 1
+        fi
+
+    # Tag must exist before npm publish so napi-rs uses it instead of HEAD
+    - name: Create and push tag
+      shell: bash
+      env:
+        RELEASE_VERSION: ${{ steps.version.outputs.value }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+        TAG_COMMIT=$(git rev-list -n 1 "v$RELEASE_VERSION" 2>/dev/null || echo "")
+        if [ "$TAG_COMMIT" != "$GITHUB_SHA" ]; then
+          git tag -a "v$RELEASE_VERSION" -m "v$RELEASE_VERSION"
+          git push origin "v$RELEASE_VERSION"
         fi
 
     - name: Publish to npm

--- a/nodejs-publish/action.yml
+++ b/nodejs-publish/action.yml
@@ -47,7 +47,7 @@ runs:
           npm publish --access public --provenance
         fi
 
-    # Must publish before packing so that the prepublishOnly script is run on the package.
+    # Package the release after the publish step so that the prepublishOnly script is run.
     - name: Pack npm artifact
       id: pack
       shell: bash

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -1,5 +1,5 @@
 name: Setup Node.js for release
-description: Validate package manager, set up Node.js, and install dependencies
+description: Validate package manager and set up Node.js, optionally installing dependencies
 
 inputs:
   node_version:
@@ -13,6 +13,10 @@ inputs:
   cache:
     description: "Whether to cache package manager dependencies"
     default: "true"
+    required: false
+  install_deps:
+    description: "Whether to install dependencies after setting up Node.js"
+    default: "false"
     required: false
 
 runs:
@@ -40,6 +44,7 @@ runs:
         package-manager-cache: false
 
     - name: Install dependencies
+      if: inputs.install_deps == 'true'
       shell: bash
       env:
         PACKAGE_MANAGER: ${{ inputs.package_manager }}

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -1,0 +1,51 @@
+name: Setup Node.js for release
+description: Validate package manager, set up Node.js, and install dependencies
+
+inputs:
+  node_version:
+    description: "Node.js version to use"
+    default: "24"
+    required: false
+  package_manager:
+    description: "Package manager used by the project: npm, yarn, or pnpm"
+    default: "npm"
+    required: false
+  cache:
+    description: "Whether to cache package manager dependencies"
+    default: "true"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        PACKAGE_MANAGER: ${{ inputs.package_manager }}
+      run: |
+        case "$PACKAGE_MANAGER" in
+          npm|yarn|pnpm) ;;
+          *) echo "::error::Unsupported package_manager '$PACKAGE_MANAGER'. Must be one of: npm, yarn, pnpm." && exit 1 ;;
+        esac
+
+    - name: Setup pnpm
+      if: inputs.package_manager == 'pnpm'
+      uses: pnpm/action-setup@v6
+
+    - uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node_version }}
+        registry-url: "https://registry.npmjs.org"
+        cache: ${{ inputs.cache == 'true' && inputs.package_manager || '' }}
+        package-manager-cache: false
+
+    - name: Install dependencies
+      shell: bash
+      env:
+        PACKAGE_MANAGER: ${{ inputs.package_manager }}
+      run: |
+        case "$PACKAGE_MANAGER" in
+          yarn) yarn install --frozen-lockfile ;;
+          pnpm) pnpm install --frozen-lockfile ;;
+          npm) npm ci ;;
+        esac


### PR DESCRIPTION
`napi-rs` is a tool used by `hc-spin-rust-utils` to create the Node.js bindings. It has it's own way of creating and managing releases. This PR aims to support `napi-rs` but also other more advanced release workflows by splitting the parts into separate actions that can be used individually by other workflows that don't want to use the reusable one from this repo.

The aim is that the existing workflows maintain their current behaviour so that repos that already use them don't need to change.

This was tested with a release of `hc-spin-rust-utils`, see here: https://github.com/holochain/hc-spin-rust-utils/actions/runs/27558394902