### PR TITLE
fix: reusable workflows were using relative paths

### DIFF
--- a/.github/workflows/nodejs-prepare-release.yml
+++ b/.github/workflows/nodejs-prepare-release.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: ./nodejs-setup
+      - uses: holochain/actions/nodejs-setup@main
         with:
           node_version: ${{ inputs.node_version }}
           package_manager: ${{ inputs.package_manager }}

--- a/.github/workflows/nodejs-publish-release.yml
+++ b/.github/workflows/nodejs-publish-release.yml
@@ -51,18 +51,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: ./nodejs-setup
+      - uses: holochain/actions/nodejs-setup@main
         with:
           node_version: ${{ inputs.node_version }}
           package_manager: ${{ inputs.package_manager }}
           cache: false # never use caching in release builds
           install_deps: true
 
-      - uses: ./nodejs-build
+      - uses: holochain/actions/nodejs-build@main
         with:
           package_manager: ${{ inputs.package_manager }}
           build_script: ${{ inputs.build_script }}
 
-      - uses: ./nodejs-publish
+      - uses: holochain/actions/nodejs-publish@main
         with:
           npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Download actionlint
         id: get_actionlint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,9 @@ name: pr.yml
 on:
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Download actionlint
         id: get_actionlint
@@ -22,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Check internal action refs use @main
         shell: bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,11 +18,27 @@ jobs:
         run: ${{ steps.get_actionlint.outputs.executable }} -color
         shell: bash
 
+  check-action-refs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check internal action refs use @main
+        shell: bash
+        run: |
+          violations=$(grep -rnP "^\s*-?\s*uses:\s*[\"']?holochain/actions/[^@\"']*@(?!main(\s|#|[\"']|$))" .github/workflows/ || true)
+          if [ -n "$violations" ]; then
+            echo "::error::Internal action refs must use @main on development branches. Run the release workflow to pin refs to a version."
+            echo "$violations"
+            exit 1
+          fi
+
   ci_pass:
     if: ${{ always() }}
     runs-on: "ubuntu-latest"
     needs:
       - actionlint
+      - check-action-refs
     steps:
       - name: check status
         uses: re-actors/alls-green@release/v1

--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -1,0 +1,71 @@
+name: Release Actions
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release with optional 'v' prefix (e.g. v1.15.0)"
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate version
+        id: version
+        env:
+          RAW_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          VERSION="v${RAW_VERSION#v}"
+          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version '${VERSION}' is not a valid semver (expected vX.Y.Z)"
+            exit 1
+          fi
+          if git ls-remote --tags origin "refs/tags/${VERSION}" | grep -q .; then
+            echo "::error::Tag ${VERSION} already exists"
+            exit 1
+          fi
+          echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+      - name: Reset stable branch to main
+        run: git checkout -B stable origin/main
+
+      - name: Pin internal action refs to release version
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        shell: bash
+        run: |
+          find .github/workflows \( -name "*.yml" -o -name "*.yaml" \) -exec sed -i \
+            "s|holochain/actions/\([^@]*\)@main|holochain/actions/\1@${VERSION}|g" \
+            {} +
+
+      - name: Commit and push stable branch
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          git add .github/workflows/
+          git commit -m "chore: release ${VERSION}"
+          git push --force origin stable
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          gh release create "${VERSION}" \
+            --title "${VERSION}" \
+            --generate-notes \
+            --target stable

--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: write
     steps:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # actions
+
 Actions for common tasks in Holochain repositories
 
 ## Referencing actions and workflows
@@ -46,10 +47,13 @@ The workflow will:
 Composite action: `mattermost-notify/action.yml`
 
 Inputs:
+
 - `mattermost_url`: base URL for Mattermost (defaults to `https://chat.holochain.org`)
-- `channel_id`: target Mattermost channel ID. This can be obtained by clicking the "(i)" icon at the top right of an open channel.
+- `channel_id`: target Mattermost channel ID. This can be obtained by
+  clicking the "(i)" icon at the top right of an open channel.
 - `message`: message text to post
-- `mattermost_personal_access_token`: Mattermost personal access token with permission to post in the channel.
+- `mattermost_personal_access_token`: Mattermost personal access token
+  with permission to post in the channel.
 
 Example usage:
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Mattermost message
-        uses: holochain/actions/mattermost-notify@main
+        uses: holochain/actions/mattermost-notify@stable
         with:
           mattermost_url: https://chat.example.com
           channel_id: your_channel_id

--- a/README.md
+++ b/README.md
@@ -1,6 +1,46 @@
 # actions
 Actions for common tasks in Holochain repositories
 
+## Referencing actions and workflows
+
+All actions and reusable workflows in this repo can be referenced with three
+levels of stability:
+
+| Ref | Example | Behaviour |
+| --- | --- | --- |
+| `@main` | `holochain/actions/mattermost-notify@main` | Latest development state. May include unreleased or breaking changes. |
+| `@stable` | `holochain/actions/mattermost-notify@stable` | Latest stable release. Moves forward on each new release. |
+| `@vX.Y.Z` | `holochain/actions/mattermost-notify@v1.15.0` | A specific release. Never changes. |
+
+For use in production, pin to a specific version tag or `@stable`.
+
+## Release process
+
+Releases are created by running the
+[Release Actions](https://github.com/holochain/actions/actions/workflows/release-actions.yml)
+workflow from the `main` branch. Provide the new version number (e.g. `1.15.0`)
+as the input.
+
+The workflow will:
+
+1. Reset the `stable` branch to the current state of `main`
+2. Replace all internal `@main` action references with `@vX.Y.Z`
+3. Commit and force-push the `stable` branch
+4. Create a GitHub release (which also creates the version tag)
+
+> [!Important]
+> Internal action refs in `.github/workflows/` must always use `@main` on
+> development branches. The PR check enforces this. The release workflow
+> handles pinning them to the release version.
+
+<!-- -->
+
+> [!Warning]
+> The `stable` branch is reset to `main` upon every release meaning that it
+> does not contain a history of all releases. Instead, each release is kept by
+> the tag reference. Because of this, no manual changes should be made to the
+> `stable` branch as they will be dropped on the next release.
+
 ## Mattermost notifier action
 
 Composite action: `mattermost-notify/action.yml`


### PR DESCRIPTION
When I split the reusable workflows into actions, I then used those actions in the reusable workflows for consistency. I used relative paths but these paths are relative to the caller and not the workflow so it didn't work, see [here](https://github.com/holochain/hc-spin-rust-utils/actions/runs/27674308509/job/81845786685). This is a limitation of reusable workflows which is normally solved by using `@main` as the tag for internal action calls, such as `holochain/actions/nodejs-setup@main`. However, this means that the `main` branch is always used no matter the pinned version of the reusable workflow which would likely cause weird issues and bugs in the future.

My solution to this is to use `@main` on the `main` branch for development purposes but then create a release automation process for this repo that, when triggered by `workflow_dispatch`, it takes the `main` branch and the provided version, it updates all the internal references to the actions to use the new version instead of `@main`, commits that change on a `stable` branch (based on the current `main`), then tags and releases that commit under the same new version.