### PR TITLE
ci: add missing workflows permission to make changes to workflow files

### DIFF
--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -14,6 +14,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: write
+      workflows: write
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
This permission is required to make changes to the workflow files.