### PR TITLE
feat: add workspace support

### DIFF
--- a/.github/workflows/nodejs-prepare-release.yml
+++ b/.github/workflows/nodejs-prepare-release.yml
@@ -79,10 +79,32 @@ jobs:
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
           PACKAGE_MANAGER: ${{ inputs.package_manager }}
         run: |
+          IS_WORKSPACE=false
+          if node -e "const p = require('./package.json'); process.exit(p.workspaces ? 0 : 1)" 2>/dev/null; then
+            IS_WORKSPACE=true
+          fi
           case "$PACKAGE_MANAGER" in
-            yarn) yarn version --new-version "$RELEASE_VERSION" --no-git-tag-version ;;
-            pnpm) pnpm version "$RELEASE_VERSION" --no-git-tag-version ;;
-            npm) npm version "$RELEASE_VERSION" --no-git-tag-version ;;
+            yarn)
+              if [ "$IS_WORKSPACE" = "true" ]; then
+                echo "::error::Workspace version bumping is not supported for yarn by this workflow. Use npm instead."
+                exit 1
+              fi
+              yarn version --new-version "$RELEASE_VERSION" --no-git-tag-version
+              ;;
+            pnpm)
+              if [ "$IS_WORKSPACE" = "true" ]; then
+                echo "::error::Workspace version bumping is not supported for pnpm by this workflow. Use npm instead."
+                exit 1
+              fi
+              pnpm version "$RELEASE_VERSION" --no-git-tag-version
+              ;;
+            npm)
+              if [ "$IS_WORKSPACE" = "true" ]; then
+                npm version "$RELEASE_VERSION" --no-git-tag-version --workspaces
+              else
+                npm version "$RELEASE_VERSION" --no-git-tag-version
+              fi
+              ;;
           esac
 
       - name: Generate changelog

--- a/.github/workflows/nodejs-publish-release.yml
+++ b/.github/workflows/nodejs-publish-release.yml
@@ -18,6 +18,10 @@ on:
         description: "npm script name to run for building the project"
         default: "build"
         required: false
+      workspace_main_package:
+        type: string
+        description: "Path to the package.json of the main package in a workspace project. Required when the project is a workspace and is used to get the version from and check if it is already published."
+        required: false
     secrets:
       NPM_TOKEN:
         description: "npm authentication token for publishing, leave blank if using Trusted Publishers"
@@ -94,3 +98,4 @@ jobs:
       - uses: holochain/actions/nodejs-publish@main
         with:
           npm_token: ${{ secrets.NPM_TOKEN }}
+          workspace_main_package: ${{ inputs.workspace_main_package }}

--- a/README.md
+++ b/README.md
@@ -42,6 +42,92 @@ The workflow will:
 > the tag reference. Because of this, no manual changes should be made to the
 > `stable` branch as they will be dropped on the next release.
 
+## Node.js release process
+
+This repo provides two reusable workflows for releasing Node.js packages.
+They implement a two-step process:
+
+1. Prepare a release PR that bumps the version and generates the changelog
+   using git-cliff.
+1. Publishes the release as an npm package and GitHub release once the prepare
+   release PR is merged.
+
+### Reusable workflows
+
+#### `nodejs-prepare-release`
+
+Determines the next version (via [git-cliff](https://git-cliff.org/) or a
+manual override), bumps the versions of all packages, generates a changelog,
+and opens a release PR with the `hra-release` label.
+
+```yaml
+jobs:
+  prepare:
+    uses: holochain/actions/.github/workflows/nodejs-prepare-release.yml@stable
+    with:
+      # required: URL to the git-cliff config to use, the usual one for Holochain projects is
+      cliff_config_url: https://raw.githubusercontent.com/holochain/release-integration/refs/heads/main/pre-1.0-cliff.toml
+      # force_version: "1.2.3"    # optional: skip version auto-detection and set version to this
+      # node_version: "24"        # default: 24
+      # package_manager: "npm"    # default: npm. One of: npm, yarn, pnpm
+      # install_deps: false       # default: false. Required by some process such as napi-rs projects
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }} # Used to create the PR and trigger the CI workflows so must not use the default GitHub token.
+```
+
+#### `nodejs-publish-release`
+
+Runs on every push to `main`. If the triggering commit came from a PR with the
+`hra-release` label, it installs dependencies, builds, publishes to npm, and
+creates a GitHub release. Non-release merges are skipped automatically.
+
+```yaml
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    uses: holochain/actions/.github/workflows/nodejs-publish-release.yml@stable
+    with:
+      # node_version: "24"         # default: 24
+      # package_manager: "npm"    # default: npm. One of: npm, yarn, pnpm
+      # build_script: "build"      # default: build
+      # workspace_main_package: "packages/pkg-1/package.json"  # required for workspace projects
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}  # omit if using npm Trusted Publishers
+```
+
+Pre-release versions (those containing a `-` in the version string, e.g.
+`1.0.0-alpha.1`) are published with the `next` tag on npm and marked as
+pre-releases on GitHub.
+
+### Using the individual actions
+
+For more complex workflows, the underlying composite actions can be used directly:
+
+- `holochain/actions/nodejs-setup@stable` — validates the package manager and
+  sets up Node.js, optionally installing dependencies
+- `holochain/actions/nodejs-build@stable` — runs the build script
+- `holochain/actions/nodejs-publish@stable` — checks the version, creates the
+  GitHub release, and publishes to npm
+
+### Workspace assumptions
+
+> [!Important]
+> Currently, only npm is supported as the package manager for workspace projects.
+
+- **Root `package.json` required**: the workspace must have a root
+  `package.json` with a `workspaces` field so the tooling can detect that it is
+  a workspace project.
+- **`workspace_main_package`**: the path to one package's `package.json` (e.g.
+  `packages/pkg-1/package.json`) must be provided. This package's `name` and
+  `version` are used to check whether the release has already been published to
+  npm.
+- **Shared version**: all packages in the workspace are expected to share the
+  same version. The prepare workflow bumps all packages to the same version
+  using `npm version --workspaces <version-number>`.
+
 ## Mattermost notifier action
 
 Composite action: `mattermost-notify/action.yml`

--- a/nodejs-publish/action.yml
+++ b/nodejs-publish/action.yml
@@ -97,6 +97,7 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
         RELEASE_VERSION: ${{ steps.version.outputs.value }}
+        TARBALL: ${{ steps.pack.outputs.tarball }}
       run: |
         PRERELEASE_FLAG=""
         if [[ "$RELEASE_VERSION" == *"-"* ]]; then
@@ -109,11 +110,11 @@ runs:
             exit 1
           fi
           gh release edit "v$RELEASE_VERSION" --title "v$RELEASE_VERSION" --notes-file /tmp/release-notes.md $PRERELEASE_FLAG
-          gh release upload "v$RELEASE_VERSION" "${{ steps.pack.outputs.tarball }}" --clobber
+          gh release upload "v$RELEASE_VERSION" "$TARBALL" --clobber
         else
           gh release create "v$RELEASE_VERSION" \
             --title "v$RELEASE_VERSION" \
             --notes-file /tmp/release-notes.md \
             $PRERELEASE_FLAG \
-            "${{ steps.pack.outputs.tarball }}"
+            "$TARBALL"
         fi

--- a/nodejs-publish/action.yml
+++ b/nodejs-publish/action.yml
@@ -99,9 +99,9 @@ runs:
         RELEASE_VERSION: ${{ steps.version.outputs.value }}
         TARBALL: ${{ steps.pack.outputs.tarball }}
       run: |
-        PRERELEASE_FLAG=""
+        RELEASE_FLAGS=()
         if [[ "$RELEASE_VERSION" == *"-"* ]]; then
-          PRERELEASE_FLAG="--prerelease"
+          RELEASE_FLAGS+=("--prerelease")
         fi
         if gh release view "v$RELEASE_VERSION" > /dev/null 2>&1; then
           TAG_COMMIT=$(gh api "repos/${{ github.repository }}/commits/v$RELEASE_VERSION" --jq '.sha')
@@ -109,12 +109,12 @@ runs:
             echo "::error::Release v$RELEASE_VERSION exists but its tag points to a different commit. Was this release already published?"
             exit 1
           fi
-          gh release edit "v$RELEASE_VERSION" --title "v$RELEASE_VERSION" --notes-file /tmp/release-notes.md $PRERELEASE_FLAG
+          gh release edit "v$RELEASE_VERSION" --title "v$RELEASE_VERSION" --notes-file /tmp/release-notes.md "${RELEASE_FLAGS[@]}"
           gh release upload "v$RELEASE_VERSION" "$TARBALL" --clobber
         else
           gh release create "v$RELEASE_VERSION" \
             --title "v$RELEASE_VERSION" \
             --notes-file /tmp/release-notes.md \
-            $PRERELEASE_FLAG \
+            "${RELEASE_FLAGS[@]}" \
             "$TARBALL"
         fi

--- a/nodejs-publish/action.yml
+++ b/nodejs-publish/action.yml
@@ -5,24 +5,51 @@ inputs:
   npm_token:
     description: "npm authentication token for publishing, leave blank if using Trusted Publishers"
     required: false
+  workspace_main_package:
+    description: "Path to the package.json of the main package in a workspace project. Required when the project uses workspaces."
+    required: false
 
 runs:
   using: composite
   steps:
-    - name: Get version
-      id: version
+    - name: Detect if project is a workspace
+      id: detect-workspace
       shell: bash
       run: |
-        VERSION=$(node -p "require('./package.json').version")
-        echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+        if node -e "const p = require('./package.json'); process.exit(p.workspaces ? 0 : 1)" 2>/dev/null; then
+          echo "is_workspace=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "is_workspace=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Get details of package to release
+      id: package_details
+      shell: bash
+      env:
+        IS_WORKSPACE: ${{ steps.detect-workspace.outputs.is_workspace }}
+        WORKSPACE_MAIN_PACKAGE: ${{ inputs.workspace_main_package }}
+      run: |
+        if [ "$IS_WORKSPACE" = "true" ]; then
+          if [ -z "$WORKSPACE_MAIN_PACKAGE" ]; then
+            echo "::error::workspace_main_package input is required for workspace projects"
+            exit 1
+          fi
+          PKG_FILE=$(node -e "const p=require('path');console.log(p.resolve(process.cwd(),process.env.WORKSPACE_MAIN_PACKAGE))")
+        else
+          PKG_FILE="$(pwd)/package.json"
+        fi
+        VERSION=$(PKG_FILE="$PKG_FILE" node -p "require(process.env.PKG_FILE).version")
+        NAME=$(PKG_FILE="$PKG_FILE" node -p "require(process.env.PKG_FILE).name")
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "name=$NAME" >> "$GITHUB_OUTPUT"
 
     - name: Check version does not already exist
       shell: bash
       env:
-        RELEASE_VERSION: ${{ steps.version.outputs.value }}
+        RELEASE_VERSION: ${{ steps.package_details.outputs.version }}
+        PACKAGE_NAME: ${{ steps.package_details.outputs.name }}
         GH_TOKEN: ${{ github.token }}
       run: |
-        PACKAGE_NAME=$(node -p "require('./package.json').name")
         if npm view "$PACKAGE_NAME@$RELEASE_VERSION" > /dev/null 2>&1; then
           echo "::error::$PACKAGE_NAME@$RELEASE_VERSION is already published to npm."
           exit 1
@@ -41,7 +68,7 @@ runs:
     - name: Create and push tag
       shell: bash
       env:
-        RELEASE_VERSION: ${{ steps.version.outputs.value }}
+        RELEASE_VERSION: ${{ steps.package_details.outputs.version }}
         GH_TOKEN: ${{ github.token }}
       run: |
         git config user.name "github-actions[bot]"
@@ -56,28 +83,39 @@ runs:
     - name: Publish to npm
       shell: bash
       env:
-        RELEASE_VERSION: ${{ steps.version.outputs.value }}
+        RELEASE_VERSION: ${{ steps.package_details.outputs.version }}
         NODE_AUTH_TOKEN: ${{ inputs.npm_token }}
         GITHUB_TOKEN: ${{ github.token }} # Required for napi-rs support
+        IS_WORKSPACE: ${{ steps.detect-workspace.outputs.is_workspace }}
       run: |
+        WORKSPACES_FLAGS=()
+        if [ "$IS_WORKSPACE" = "true" ]; then
+          WORKSPACES_FLAGS=("--workspaces")
+        fi
         if [[ "$RELEASE_VERSION" == *"-"* ]]; then
-          npm publish --access public --provenance --tag next
+          npm publish "${WORKSPACES_FLAGS[@]}" --access public --provenance --tag next
         else
-          npm publish --access public --provenance
+          npm publish "${WORKSPACES_FLAGS[@]}" --access public --provenance
         fi
 
     # Package the release after the publish step so that the prepublishOnly script is run.
     - name: Pack npm artifact
       id: pack
       shell: bash
+      env:
+        IS_WORKSPACE: ${{ steps.detect-workspace.outputs.is_workspace }}
       run: |
-        TARBALL=$(npm pack)
-        echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+        WORKSPACES_FLAGS=()
+        if [ "$IS_WORKSPACE" = "true" ]; then
+          WORKSPACES_FLAGS=("--workspaces")
+        fi
+        TARBALLS=$(npm pack "${WORKSPACES_FLAGS[@]}" | tr '\n' ' ' | xargs)
+        echo "tarballs=$TARBALLS" >> "$GITHUB_OUTPUT"
 
     - name: Extract release notes from changelog
       shell: bash
       env:
-        RELEASE_VERSION: ${{ steps.version.outputs.value }}
+        RELEASE_VERSION: ${{ steps.package_details.outputs.version }}
       run: |
         awk -v version="$RELEASE_VERSION" '
           /^## / {
@@ -96,13 +134,14 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
-        RELEASE_VERSION: ${{ steps.version.outputs.value }}
-        TARBALL: ${{ steps.pack.outputs.tarball }}
+        RELEASE_VERSION: ${{ steps.package_details.outputs.version }}
+        TARBALLS: ${{ steps.pack.outputs.tarballs }}
       run: |
         RELEASE_FLAGS=()
         if [[ "$RELEASE_VERSION" == *"-"* ]]; then
           RELEASE_FLAGS+=("--prerelease")
         fi
+        read -ra TARBALL_ARGS <<< "$TARBALLS"
         if gh release view "v$RELEASE_VERSION" > /dev/null 2>&1; then
           TAG_COMMIT=$(gh api "repos/${{ github.repository }}/commits/v$RELEASE_VERSION" --jq '.sha')
           if [ "$TAG_COMMIT" != "$GITHUB_SHA" ]; then
@@ -110,11 +149,13 @@ runs:
             exit 1
           fi
           gh release edit "v$RELEASE_VERSION" --title "v$RELEASE_VERSION" --notes-file /tmp/release-notes.md "${RELEASE_FLAGS[@]}"
-          gh release upload "v$RELEASE_VERSION" "$TARBALL" --clobber
+          for tarball in "${TARBALL_ARGS[@]}"; do
+            gh release upload "v$RELEASE_VERSION" "$tarball" --clobber
+          done
         else
           gh release create "v$RELEASE_VERSION" \
             --title "v$RELEASE_VERSION" \
             --notes-file /tmp/release-notes.md \
             "${RELEASE_FLAGS[@]}" \
-            "$TARBALL"
+            "${TARBALL_ARGS[@]}"
         fi


### PR DESCRIPTION
Automatically detect if the project is in a workspace and use the `--workspace` flag for `npm release` if it is. The new `version_file` input is required to know where to read the new version from and to get the package name to check if that version already exists.

This assumes that all the packages are released under the same version.

This successfully worked with publishing `v0.0.8` of the NPM test repo: https://github.com/holochain/npm-release-test/actions/runs/28855732581