### PR TITLE
Fix previous tag detection in this repo's release automation

### DIFF
--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -37,6 +37,13 @@ jobs:
           fi
           echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Get previous tag
+        id: previous_tag
+        shell: bash
+        run: |
+          PREVIOUS_TAG=$(git tag --sort=-version:refname | head -1)
+          echo "value=${PREVIOUS_TAG}" >> "$GITHUB_OUTPUT"
+
       - name: Configure git
         run: |
           git config user.name "GitHub Actions"
@@ -66,8 +73,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.value }}
+          PREVIOUS_TAG: ${{ steps.previous_tag.outputs.value }}
         run: |
           gh release create "${VERSION}" \
             --title "${VERSION}" \
             --generate-notes \
+            --notes-start-tag "$PREVIOUS_TAG" \
             --target stable

--- a/nodejs-publish/action.yml
+++ b/nodejs-publish/action.yml
@@ -12,7 +12,9 @@ runs:
     - name: Get version
       id: version
       shell: bash
-      run: echo "value=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+      run: |
+        VERSION=$(node -p "require('./package.json').version")
+        echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Check version does not already exist
       shell: bash

--- a/nodejs-publish/action.yml
+++ b/nodejs-publish/action.yml
@@ -109,7 +109,7 @@ runs:
             exit 1
           fi
           gh release edit "v$RELEASE_VERSION" --title "v$RELEASE_VERSION" --notes-file /tmp/release-notes.md $PRERELEASE_FLAG
-          gh release upload "v$RELEASE_VERSION" "${{ steps.pack.outputs.tarball }}"
+          gh release upload "v$RELEASE_VERSION" "${{ steps.pack.outputs.tarball }}" --clobber
         else
           gh release create "v$RELEASE_VERSION" \
             --title "v$RELEASE_VERSION" \


### PR DESCRIPTION
Creating a new release via the GH API uses the previous tag on the current branch by default but the release workflow resets the `stable` branch just before creating a release which means the previous tag was not on this branch and therefore not detected correctly.

Also do some small boy-scouting.